### PR TITLE
Logo and Timeout changes

### DIFF
--- a/2015-01-27 MacBrained Reissuing FileVault Keys/reissue_filevault_recovery_key.sh
+++ b/2015-01-27 MacBrained Reissuing FileVault Keys/reissue_filevault_recovery_key.sh
@@ -59,7 +59,7 @@ if [[ ! -f "$LOGO_ICNS" ]]; then
     exit 1001
 fi
 # Convert POSIX path of logo icon to Mac path for AppleScript
-LOGO_ICNS="$(osascript -e "POSIX file \"$LOGO_ICNS\" as text")"
+LOGO_ICNS="$(osascript -e 'tell application "System Events" to return POSIX file "'"$LOGO_ICNS"'" as text')"
 
 # Most of the code below is based on the JAMF reissueKey.sh script:
 # https://github.com/JAMFSupport/FileVault2_Scripts/blob/master/reissueKey.sh


### PR DESCRIPTION
1. Changed LOGO_ICS to use a standard unix path which is converted to
   mac path.
2. Added timeout (24 hours) to the dialog display which asks for
   password. Otherwise it times out after 2 minutes and will fail if the
   user is away from their computer.
