### PR TITLE
Osascript running as user instead of root

### DIFF
--- a/2015-01-27 MacBrained Reissuing FileVault Keys/reissue_filevault_recovery_key.sh
+++ b/2015-01-27 MacBrained Reissuing FileVault Keys/reissue_filevault_recovery_key.sh
@@ -110,14 +110,14 @@ echo "Alerting user ${userName} about incoming password prompt..."
 
 # Get the logged in user's password via a prompt
 echo "Prompting ${userName} for their Mac password..."
-userPass="$(/usr/bin/osascript -e 'tell application "System Events"' -e 'with timeout of 86400 seconds' -e 'display dialog "Please enter your Mac password:" default answer "" with title "'"${COMPANY_NAME//\"/\\\"}"' IT encryption key repair" with text buttons {"OK"} default button 1 with hidden answer with icon file "'"${LOGO_ICNS//\"/\\\"}"'"' -e 'return text returned of result' -e 'end timeout' -e 'end tell')"
+userPass="$(/usr/bin/sudo -u $userName /usr/bin/osascript -e 'tell application "System Events" to display dialog "Please enter your Mac password:" default answer "" with title "'"${COMPANY_NAME//\"/\\\"}"' IT encryption key repair" with text buttons {"OK"} default button 1 with hidden answer with icon file "'"${LOGO_ICNS//\"/\\\"}"'"' -e 'text returned of result')"
 
 # Thanks to James Barclay for this password validation loop.
 TRY=1
 until dscl /Search -authonly "$userName" "$userPass" &> /dev/null; do
     (( TRY++ ))
     echo "Prompting ${userName} for their Mac password (attempt $TRY)..."
-    userPass="$(/usr/bin/osascript -e 'tell application "System Events"' -e 'with timeout of 86400 seconds' -e 'display dialog "Sorry, that password was incorrect. Please try again:" default answer "" with title "'"${COMPANY_NAME//\"/\\\"}"' IT encryption key repair" with text buttons {"OK"} default button 1 with hidden answer with icon file "'"${LOGO_ICNS//\"/\\\"}"'"' -e 'return text returned of result' -e 'end timeout' -e 'end tell')"
+    userPass="$(/usr/bin/sudo -u $userName /usr/bin/osascript -e 'tell application "System Events" to display dialog "Please enter your Mac password:" default answer "" with title "'"${COMPANY_NAME//\"/\\\"}"' IT encryption key repair" with text buttons {"OK"} default button 1 with hidden answer with icon file "'"${LOGO_ICNS//\"/\\\"}"'"' -e 'text returned of result')"
     if [[ $TRY -ge 5 ]]; then
         echo "[ERROR] Password prompt unsuccessful after 5 attempts."
         exit 1007


### PR DESCRIPTION
Don’t know what changed in 10.11 but what we found is that the osacript
bits fail when the JSS calls it with a trigger. It seems to fail
because it is trying to auth as root and not the user. This is what we
added and it seems to fix it.
