### PR TITLE
Display and exit with fdesetup exit code

### DIFF
--- a/2015-01-27 MacBrained Reissuing FileVault Keys/reissue_filevault_recovery_key.sh
+++ b/2015-01-27 MacBrained Reissuing FileVault Keys/reissue_filevault_recovery_key.sh
@@ -154,4 +154,4 @@ echo "Loading FDERecoveryAgent..."
 # `fdesetup changerecovery` should do this automatically, but just in case...
 launchctl load /System/Library/LaunchDaemons/com.apple.security.FDERecoveryAgent.plist &>/dev/null
 
-exit 0
+exit $result

--- a/2015-01-27 MacBrained Reissuing FileVault Keys/reissue_filevault_recovery_key.sh
+++ b/2015-01-27 MacBrained Reissuing FileVault Keys/reissue_filevault_recovery_key.sh
@@ -145,8 +145,9 @@ fdesetup changerecovery -norecoverykey -verbose -personal -inputplist << EOF
 </plist>
 EOF
 
-if [[ $? -ne 0 ]]; then
-    echo "[WARNING] fdesetup did not return exit code 0."
+result=$?
+if [[ $result -ne 0 ]]; then
+    echo "[WARNING] fdesetup exited with return code: $result."
 fi
 
 echo "Loading FDERecoveryAgent..."


### PR DESCRIPTION
These changes display the exit code from fdesetup for better troubleshooting. For better error Casper support, the exit code doesn't always return 0 either so that the policy can show as failed.
